### PR TITLE
Add GPyGPSurrogate model

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ matplotlib = "*"
 seaborn = "*"
 direct = "*"
 bopy = {editable = true,path = "."}
+gpy = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "51bdb4d750dba0550be3265002a694a72d3ccef356fdcfeaaa44f66f789ab9a1"
+            "sha256": "cc81c4d3c9604a96af7a7e6be9a80f178eaf795e8944974df0907654a9b524d6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -27,12 +27,34 @@
             ],
             "version": "==0.10.0"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce",
+                "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"
+            ],
+            "version": "==4.4.1"
+        },
         "direct": {
             "hashes": [
                 "sha256:0506117d7d9dceea21805a8c41e3cb331712319187a30930142453eb61728cb4"
             ],
             "index": "pypi",
             "version": "==1.0.1"
+        },
+        "gpy": {
+            "hashes": [
+                "sha256:04faf0c24eacc4dea60727c50a48a07ddf9b5751a3b73c382105e2a31657c7ed",
+                "sha256:216e292c96e3d37f76bd135240a9d81f3815fa2b547c9df1525f7f71c95bfdf1",
+                "sha256:3b30fa21219b97116482cb1645113ba3ba377090246fefe259656dcaddd74655",
+                "sha256:41e0c9e81a7ccd16096d59374717d2724ec7ef5b16dbb302a53a2c72191c8325",
+                "sha256:567dda4c9fdcc3caf38319729426cbb487bff61cca586867c74e01e0cf616081",
+                "sha256:795c28b2e32ea56bc5e34843ef85651d0b1e3e8370e82a7c31a02d5b90e8b184",
+                "sha256:882ca501a6fbbf8229b8231db021f5fdd2d3a5c699bde5a6e7c7715065a7309e",
+                "sha256:b3a1e58dbe74dec74b0c416c18f136444859b33d13f99d5b843c1e03b6f0f6c2",
+                "sha256:ec4435a475dc3744cffc34d803f964955ae2371213387344878a08b21c476ded"
+            ],
+            "index": "pypi",
+            "version": "==1.9.9"
         },
         "joblib": {
             "hashes": [
@@ -85,22 +107,23 @@
         },
         "matplotlib": {
             "hashes": [
-                "sha256:08ccc8922eb4792b91c652d3e6d46b1c99073f1284d1b6705155643e8046463a",
-                "sha256:161dcd807c0c3232f4dcd4a12a382d52004a498174cbfafd40646106c5bcdcc8",
-                "sha256:1f9e885bfa1b148d16f82a6672d043ecf11197f6c71ae222d0546db706e52eb2",
-                "sha256:2d6ab54015a7c0d727c33e36f85f5c5e4172059efdd067f7527f6e5d16ad01aa",
-                "sha256:5d2e408a2813abf664bd79431107543ecb449136912eb55bb312317edecf597e",
-                "sha256:61c8b740a008218eb604de518eb411c4953db0cb725dd0b32adf8a81771cab9e",
-                "sha256:80f10af8378fccc136da40ea6aa4a920767476cdfb3241acb93ef4f0465dbf57",
-                "sha256:819d4860315468b482f38f1afe45a5437f60f03eaede495d5ff89f2eeac89500",
-                "sha256:8cc0e44905c2c8fda5637cad6f311eb9517017515a034247ab93d0cf99f8bb7a",
-                "sha256:8e8e2c2fe3d873108735c6ee9884e6f36f467df4a143136209cff303b183bada",
-                "sha256:98c2ffeab8b79a4e3a0af5dd9939f92980eb6e3fec10f7f313df5f35a84dacab",
-                "sha256:d59bb0e82002ac49f4152963f8a1079e66794a4f454457fd2f0dcc7bf0797d30",
-                "sha256:ee59b7bb9eb75932fe3787e54e61c99b628155b0cedc907864f24723ba55b309"
+                "sha256:23b71560c721109954c0215ffc81f4c80ce8528749d534a01a61e8ab737c5bce",
+                "sha256:4164265ca573481ce61c83322e6b33628203afeabeb3e22c50376f5d3ee0f9be",
+                "sha256:470eed601ff5132364e0121a20d7c3d43fab969c8c333422c1b6b72fde2ed3c1",
+                "sha256:635ded7834f43c8d999076236f7e90074d77f7b8345e5e82cd95af053cc29df1",
+                "sha256:6a0031774c6c68298183438edf2e738856d63a4c4797876fa81d0ee337f5361c",
+                "sha256:78d0772412c0653aa3e860c52ff08d1f5ba64334e2b86b09dc2d502657d8ca73",
+                "sha256:8efff896c49676700dc6adace6137a854ff64a4d44ca057ff726960ffdaa47bf",
+                "sha256:97f04d29a358826f205320fbc88d46ce5c5ff6fb54ae050042ff396beda52ca4",
+                "sha256:b4c0010eff09ab65c77ad1a0eec6c7cccb9f6838c3c77dc5b4002fe0cf2912fd",
+                "sha256:b5ace0531255932ad19fe64c116ada2713f7b38381db8f68df0fa694409e67d1",
+                "sha256:c7bb7ed3e011324b56462391ec3f4bbb7c8c6af5892ebfb45d312b15b4cdfc8d",
+                "sha256:db3121f12fb9b99f105d1413aebaeb3d943f269f3d262b45586d12765866f0c6",
+                "sha256:db8bbba9284845034a2f0e1add91dc5e89db8c996359bdcf677a8d6f88875cf1",
+                "sha256:f0023322c99328c40ce22678ab0ab5adfc27e338419966539398239996f63e8d"
             ],
             "index": "pypi",
-            "version": "==3.1.2"
+            "version": "==3.1.3"
         },
         "numpy": {
             "hashes": [
@@ -131,27 +154,28 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:00dff3a8e337f5ed7ad295d98a31821d3d0fe7792da82d78d7fd79b89c03ea9d",
-                "sha256:22361b1597c8c2ffd697aa9bf85423afa9e1fcfa6b1ea821054a244d5f24d75e",
-                "sha256:255920e63850dc512ce356233081098554d641ba99c3767dde9e9f35630f994b",
-                "sha256:26382aab9c119735908d94d2c5c08020a4a0a82969b7e5eefb92f902b3b30ad7",
-                "sha256:33970f4cacdd9a0ddb8f21e151bfb9f178afb7c36eb7c25b9094c02876f385c2",
-                "sha256:4545467a637e0e1393f7d05d61dace89689ad6d6f66f267f86fff737b702cce9",
-                "sha256:52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4",
-                "sha256:61741f5aeb252f39c3031d11405305b6d10ce663c53bc3112705d7ad66c013d0",
-                "sha256:6a3ac2c87e4e32a969921d1428525f09462770c349147aa8e9ab95f88c71ec71",
-                "sha256:7458c48e3d15b8aaa7d575be60e1e4dd70348efcd9376656b72fecd55c59a4c3",
-                "sha256:78bf638993219311377ce9836b3dc05f627a666d0dbc8cec37c0ff3c9ada673b",
-                "sha256:8153705d6545fd9eb6dd2bc79301bff08825d2e2f716d5dced48daafc2d0b81f",
-                "sha256:975c461accd14e89d71772e89108a050fa824c0b87a67d34cedf245f6681fc17",
-                "sha256:9962957a27bfb70ab64103d0a7b42fa59c642fb4ed4cb75d0227b7bb9228535d",
-                "sha256:adc3d3a3f9e59a38d923e90e20c4922fc62d1e5a03d083440468c6d8f3f1ae0a",
-                "sha256:bbe3eb765a0b1e578833d243e2814b60c825b7fdbf4cdfe8e8aae8a08ed56ecf",
-                "sha256:df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133",
-                "sha256:e45055c30a608076e31a9fcd780a956ed3b1fa20db61561b8d88b79259f526f7",
-                "sha256:ee50c2142cdcf41995655d499a157d0a812fce55c97d9aad13bc1eef837ed36c"
+                "sha256:23e177d43e4bf68950b0f8788b6a2fef2f478f4ec94883acb627b9264522a98a",
+                "sha256:2530aea4fe46e8df7829c3f05e0a0f821c893885d53cb8ac9b89cc67c143448c",
+                "sha256:303827f0bb40ff610fbada5b12d50014811efcc37aaf6ef03202dc3054bfdda1",
+                "sha256:3b019e3ea9f5d0cfee0efabae2cfd3976874e90bcc3e97b29600e5a9b345ae3d",
+                "sha256:3c07765308f091d81b6735d4f2242bb43c332cc3461cae60543df6b10967fe27",
+                "sha256:5036d4009012a44aa3e50173e482b664c1fae36decd277c49e453463798eca4e",
+                "sha256:6f38969e2325056f9959efbe06c27aa2e94dd35382265ad0703681d993036052",
+                "sha256:74a470d349d52b9d00a2ba192ae1ee22155bb0a300fd1ccb2961006c3fa98ed3",
+                "sha256:7d77034e402165b947f43050a8a415aa3205abfed38d127ea66e57a2b7b5a9e0",
+                "sha256:7f9a509f6f11fa8b9313002ebdf6f690a7aa1dd91efd95d90185371a0d68220e",
+                "sha256:942b5d04762feb0e55b2ad97ce2b254a0ffdd344b56493b04a627266e24f2d82",
+                "sha256:a9fbe41663416bb70ed05f4e16c5f377519c0dc292ba9aa45f5356e37df03a38",
+                "sha256:d10e83866b48c0cdb83281f786564e2a2b51a7ae7b8a950c3442ad3c9e36b48c",
+                "sha256:e2140e1bbf9c46db9936ee70f4be6584d15ff8dc3dfff1da022d71227d53bad3"
             ],
-            "version": "==0.25.3"
+            "version": "==1.0.1"
+        },
+        "paramz": {
+            "hashes": [
+                "sha256:0917211c0f083f344e7f1bc997e0d713dbc147b6380bc19f606119394f820b9a"
+            ],
+            "version": "==0.9.5"
         },
         "pydoe": {
             "hashes": [
@@ -289,11 +313,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359",
-                "sha256:f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8"
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "isort": {
             "hashes": [
@@ -305,10 +329,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:1a2a32c72400d365000412fe08eb4a24ebee89997c18d3d147544f70f5403b39",
-                "sha256:c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288"
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
             ],
-            "version": "==8.1.0"
+            "version": "==8.2.0"
         },
         "packaging": {
             "hashes": [
@@ -347,11 +371,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1d122e8be54d1a709e56f82e2d85dcba3018313d64647f38a91aec88c239b600",
-                "sha256:c13d1943c63e599b98cf118fcb9703e4d7bde7caa9a432567bcdcae4bf512d20"
+                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
+                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
             ],
             "index": "pypi",
-            "version": "==5.3.4"
+            "version": "==5.3.5"
         },
         "regex": {
             "hashes": [
@@ -428,10 +452,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28",
-                "sha256:feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"
+                "sha256:5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50",
+                "sha256:d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e"
             ],
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         }
     }
 }

--- a/bopy/surrogate.py
+++ b/bopy/surrogate.py
@@ -149,7 +149,7 @@ class GPyGPSurrogate(Surrogate):
         self._optimize_gp()
 
     def _predict(self, x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-        mu, sigma = self.gp.predict(x, full_cov=True)
+        mu, sigma = self.gp.predict_noiseless(x, full_cov=True)
         return mu.flatten(), sigma
 
     def _update_gp(self, x: np.ndarray, y: np.ndarray):

--- a/bopy/surrogate.py
+++ b/bopy/surrogate.py
@@ -1,5 +1,6 @@
 from typing import Callable, Tuple
 
+import GPy
 import numpy as np
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.preprocessing import StandardScaler
@@ -145,14 +146,18 @@ class GPyGPSurrogate(Surrogate):
 
     Parameters
     ----------
-    gp_initizlizer: Callable
+    gp_initizlizer: Callable[[np.ndarray, np.ndarray] -> GPy.models.GPRegression]
         A function that accepts training data and
         returns a GPy GP model.
     n_restarts: Integer (default = 1)
         The number of restarts during optimization.
     """
 
-    def __init__(self, gp_initializer, n_restarts=1):
+    def __init__(
+        self,
+        gp_initializer: Callable[[np.ndarray, np.ndarray], GPy.models.GPRegression],
+        n_restarts: int = 1,
+    ):
         super().__init__()
         self.gp_initializer = gp_initializer
         self.n_restarts = n_restarts

--- a/bopy/surrogate.py
+++ b/bopy/surrogate.py
@@ -129,13 +129,27 @@ class ScipyGPSurrogate(Surrogate):
 class GPyGPSurrogate(Surrogate):
     """GPy GP Surrogate.
 
-    This is a wrapper around the GPy
-    GPRegression model.
+    This is a wrapper around a GPy GPRegression model.
+
+    Due to the fact that GPy models are instantiated
+    with training data but no such data is available when
+    constructing a BayesOpt object, a level of indirection is
+    required. Instead of passing the surrogate an instantiated
+    GPy model, one must pass a function that will instantiate and
+    then return a model given data. The signature should look like:
+
+    def gp_initialzier(x: np.ndarray, y: np.ndarray):
+        gp = GPy.models.GPRegression(...)
+        ...set constraints, or priors, or whatever...
+        return gp
 
     Parameters
     ----------
-    gp: GaussianProcessRegressor
-        The scikit-learn GP regressor.
+    gp_initizlizer: Callable
+        A function that accepts training data and
+        returns a GPy GP model.
+    n_restarts: Integer (default = 1)
+        The number of restarts during optimization.
     """
 
     def __init__(self, gp_initializer, n_restarts=1):

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -49,7 +49,7 @@ def test_training_data_must_contain_at_least_one_sample(surrogate):
 @pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
 def test_training_input_and_target_must_be_the_same_size(surrogate):
     # ARRANGE
-    n_dimensions = 10
+    n_dimensions = 1
     n_samples_x = 15
     n_samples_y = 5
 
@@ -86,7 +86,7 @@ def test_training_target_must_be_1d(surrogate):
 @pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
 def test_fit_must_be_called_before_predict(surrogate):
     # ARRANGE
-    n_dimensions = 10
+    n_dimensions = 1
     n_samples = 100
 
     x, y = make_regression(n_samples, n_dimensions)
@@ -99,7 +99,7 @@ def test_fit_must_be_called_before_predict(surrogate):
 @pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
 def test_predict_returns_correct_dimensions(surrogate):
     # ARRANGE
-    n_dimensions = 10
+    n_dimensions = 1
     n_samples = 100
 
     x, y = make_regression(n_samples, n_dimensions)
@@ -117,7 +117,7 @@ def test_predict_returns_correct_dimensions(surrogate):
 @pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
 def test_test_input_contains_at_least_one_sample(surrogate):
     # ARRANGE
-    n_dimensions = 10
+    n_dimensions = 1
     n_samples = 100
 
     x_train, y_train = make_regression(n_samples, n_dimensions)
@@ -133,7 +133,7 @@ def test_test_input_contains_at_least_one_sample(surrogate):
 @pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
 def test_test_input_must_be_2d(surrogate):
     # ARRANGE
-    n_dimensions = 10
+    n_dimensions = 1
     n_samples = 100
 
     x_train, y_train = make_regression(n_samples, n_dimensions)
@@ -149,10 +149,10 @@ def test_test_input_must_be_2d(surrogate):
 @pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
 def test_test_input_must_have_same_number_of_dimensions_as_training_input(surrogate):
     # ARRANGE
-    n_dimensions_train = 10
-    n_samples_train = 100
+    n_dimensions_train = 1
+    n_samples_train = 10
 
-    n_dimensions_test = 100
+    n_dimensions_test = 15
     n_samples_test = 10
 
     x_train, y_train = make_regression(n_samples_train, n_dimensions_train)
@@ -214,7 +214,7 @@ def test_gps_return_to_the_prior_far_away_from_the_training_data(surrogate):
 def test_GPyGPSurrogate_instantiates_a_gp_after_calling_fit():
     # ARRANGE
     n_dimensions = 1
-    n_samples = 100
+    n_samples = 10
     x, y = make_regression(n_samples, n_dimensions)
     surrogate = gpy_gp_surrogate()
 
@@ -228,7 +228,7 @@ def test_GPyGPSurrogate_instantiates_a_gp_after_calling_fit():
 def test_GPyGPSurrogate_updates_data_on_second_call_to_fit():
     # ARRANGE
     n_dimensions = 1
-    n_samples = 100
+    n_samples = 10
     x1, y1 = make_regression(n_samples, n_dimensions)
     x2, y2 = make_regression(n_samples, n_dimensions)
     surrogate = gpy_gp_surrogate()

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -118,7 +118,7 @@ def test_predict_returns_correct_dimensions(surrogate):
 def test_test_input_contains_at_least_one_sample(surrogate):
     # ARRANGE
     n_dimensions = 1
-    n_samples = 100
+    n_samples = 10
 
     x_train, y_train = make_regression(n_samples, n_dimensions)
     x_test = np.array([])
@@ -134,7 +134,7 @@ def test_test_input_contains_at_least_one_sample(surrogate):
 def test_test_input_must_be_2d(surrogate):
     # ARRANGE
     n_dimensions = 1
-    n_samples = 100
+    n_samples = 10
 
     x_train, y_train = make_regression(n_samples, n_dimensions)
     x_test = np.zeros((n_samples, n_dimensions, 1))
@@ -215,7 +215,10 @@ def test_GPyGPSurrogate_instantiates_a_gp_after_calling_fit():
     # ARRANGE
     n_dimensions = 1
     n_samples = 10
-    x, y = make_regression(n_samples, n_dimensions)
+
+    x = np.linspace(0.0, 1.0, n_samples).reshape(-1, 1)
+    y = np.sin(x.flatten())
+
     surrogate = gpy_gp_surrogate()
 
     # ACT
@@ -229,8 +232,13 @@ def test_GPyGPSurrogate_updates_data_on_second_call_to_fit():
     # ARRANGE
     n_dimensions = 1
     n_samples = 10
-    x1, y1 = make_regression(n_samples, n_dimensions)
-    x2, y2 = make_regression(n_samples, n_dimensions)
+
+    x1 = np.linspace(0.0, 1.0, n_samples).reshape(-1, 1)
+    y1 = np.sin(x1.flatten())
+
+    x2 = np.linspace(1.0, 2.0, n_samples).reshape(-1, 1)
+    y2 = np.sin(x2.flatten())
+
     surrogate = gpy_gp_surrogate()
     surrogate.fit(x1, y1)
 


### PR DESCRIPTION
Add GPyGPSurrogate as another potential surrogate model. This is a wrapper around GPy GPRegression. This should be more stable than the scipy one.

Unfortunately, GPy is doing something with the paramz library that is deprecated. The test suite now raises a large number of warnings 😞 