### PR TITLE
Add reference to surrogate in acquisition function

### DIFF
--- a/bopy/acquisition.py
+++ b/bopy/acquisition.py
@@ -21,10 +21,11 @@ class AcquisitionFunction(ABC):
     This class shouldn't be used directly, use a derived class instead.
     """
 
-    def __init__(self):
+    def __init__(self, surrogate: Surrogate):
+        self.surrogate = surrogate
         self.is_fitted = False
 
-    def __call__(self, surrogate: Surrogate, x: np.ndarray) -> np.ndarray:
+    def __call__(self, x: np.ndarray) -> np.ndarray:
         """Evaluate the acquisition function.
 
         Parameters
@@ -44,7 +45,7 @@ class AcquisitionFunction(ABC):
         if not self.is_fitted:
             raise NotFittedError("must call fit before evaluating.")
 
-        return self._f(*surrogate.predict(x))
+        return self._f(*self.surrogate.predict(x))
 
     @abstractmethod
     def _f(self, mean: np.ndarray, sigma: np.ndarray) -> np.ndarray:
@@ -79,8 +80,8 @@ class LCB(AcquisitionFunction):
         The number of stds we subtract from the mean.
     """
 
-    def __init__(self, kappa: float = 2.0):
-        super().__init__()
+    def __init__(self, surrogate: Surrogate, kappa: float = 2.0):
+        super().__init__(surrogate)
         self.kappa = kappa
 
     def _f(self, mean: np.ndarray, sigma: np.ndarray) -> np.ndarray:
@@ -94,8 +95,8 @@ class EI(AcquisitionFunction):
         `ei(x) = -E[|eta - f(x)|+]`
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, surrogate: Surrogate):
+        super().__init__(surrogate)
         self._eta = np.inf
 
     def _f(self, mean: np.ndarray, sigma: np.ndarray):
@@ -117,8 +118,8 @@ class POI(AcquisitionFunction):
         `poi(x) = p(f(x) >= eta)`
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, surrogate: Surrogate):
+        super().__init__(surrogate)
         self._eta = np.inf
 
     def _f(self, mean: np.ndarray, sigma: np.ndarray):

--- a/bopy/bayes_opt.py
+++ b/bopy/bayes_opt.py
@@ -238,7 +238,7 @@ class BayesOpt:
     def optimize_acquisition(self) -> OptimizationResult:
         """Optimize the acquisition function."""
         result = self.optimizer.optimize(
-            self.acquisition_function, self.surrogate, self.bounds
+            self.acquisition_function, self.bounds
         )
         self.dispatch("on_acquisition_optimized", self, result)
 

--- a/bopy/optimizer.py
+++ b/bopy/optimizer.py
@@ -38,10 +38,7 @@ class Optimizer(ABC):
     """
 
     def optimize(
-        self,
-        acquisition_function: AcquisitionFunction,
-        surrogate: Surrogate,
-        bounds: Bounds,
+        self, acquisition_function: AcquisitionFunction, bounds: Bounds,
     ) -> OptimizationResult:
         """Optimize an acquisition function.
 
@@ -52,8 +49,6 @@ class Optimizer(ABC):
         ----------
         acquisition_function: AcquisitionFunction
             The acquisition function.
-        surrogate: Surrogate
-            The surrogate model.
         bounds: Bounds
             The parameter bounds.
 
@@ -62,15 +57,12 @@ class Optimizer(ABC):
         optimization_result: OptimizationResult
             The result of optimization.
         """
-        x_min, f_min = self._optimize(acquisition_function, surrogate, bounds)
+        x_min, f_min = self._optimize(acquisition_function, bounds)
         return OptimizationResult(x_min=x_min, f_min=f_min)
 
     @abstractmethod
     def _optimize(
-        self,
-        acquisition_function: AcquisitionFunction,
-        surrogate: Surrogate,
-        bounds: Bounds,
+        self, acquisition_function: AcquisitionFunction, bounds: Bounds,
     ) -> Tuple[np.ndarray, float]:
         raise NotImplementedError
 
@@ -94,13 +86,10 @@ class DirectOptimizer(Optimizer):
         self.direct_kwargs = direct_kwargs
 
     def _optimize(
-        self,
-        acquisition_function: AcquisitionFunction,
-        surrogate: Surrogate,
-        bounds: Bounds,
+        self, acquisition_function: AcquisitionFunction, bounds: Bounds,
     ) -> Tuple[np.ndarray, float]:
         def wrapped_f(x, _):
-            return acquisition_function(surrogate, x.reshape(1, -1)), 0
+            return acquisition_function(x.reshape(1, -1)), 0
 
         x_min, f_min, _ = solve(
             wrapped_f,

--- a/bopy/plotting.py
+++ b/bopy/plotting.py
@@ -57,7 +57,6 @@ def plot_surrogate_1D(
 def plot_acquisition_function_1D(
     ax: plt.Axes,
     acquisition_function: AcquisitionFunction,
-    surrogate: Surrogate,
     bound: Bound,
     n_points: int = 100,
 ) -> None:
@@ -70,8 +69,6 @@ def plot_acquisition_function_1D(
         to plot the graph.
     acquisition_function: AcquisitionFunction
         A trained acquisition function.
-    surrogate: Surrogate
-        A trained surrogate model.
     bound: Bound
         The bound on which to plot
         the graph. NB: doesn't have to be
@@ -81,7 +78,7 @@ def plot_acquisition_function_1D(
         to plot the graph.
     """
     x = np.linspace(bound.lower, bound.upper, n_points).reshape(-1, 1)
-    a_x = acquisition_function(surrogate, x)
+    a_x = acquisition_function(x)
 
     ax.plot(x.flatten(), a_x, label="acquisition function")
 

--- a/examples/example_1d.py
+++ b/examples/example_1d.py
@@ -40,9 +40,7 @@ class PlottingCallback(Callback):
         ax = self.axs[self.current_trial][0]
 
         plot_surrogate_1D(ax, bo.surrogate, bo.x, bo.y, bo.bounds.bounds[0])
-        plot_acquisition_function_1D(
-            ax, bo.acquisition_function, bo.surrogate, bo.bounds.bounds[0]
-        )
+        plot_acquisition_function_1D(ax, bo.acquisition_function, bo.bounds.bounds[0])
         ax.plot(opt_result.x_min, opt_result.f_min, "r*", label="acquisition min")
 
     def on_surrogate_updated(self, bo):
@@ -73,12 +71,13 @@ def gp_initializer(x, y):
 
 
 surrogate = GPyGPSurrogate(gp_initializer=gp_initializer)
+acquistion_function = LCB(surrogate=surrogate)
 
 # Now we create the BO object...
 bo = BayesOpt(
     objective_function=forrester,
     surrogate=surrogate,
-    acquisition_function=LCB(),
+    acquisition_function=acquistion_function,
     optimizer=DirectOptimizer(maxf=100),
     initial_design=SobolSequenceInitialDesign(),
     bounds=Bounds(bounds=[Bound(lower=0.0, upper=1.0)]),

--- a/tests/test_acquisiton.py
+++ b/tests/test_acquisiton.py
@@ -9,39 +9,61 @@ from bopy.exceptions import NotFittedError
 from bopy.surrogate import ScipyGPSurrogate
 
 
-@pytest.mark.parametrize("acquisition", [EI(), LCB(), POI()])
-def test_fit_must_be_called_before_evaluating(acquisition):
+def ei_and_surrogate():
+    surrogate = ScipyGPSurrogate(gp=GaussianProcessRegressor(kernel=Matern()))
+    ei = EI(surrogate=surrogate)
+
+    return ei, surrogate
+
+
+def lcb_and_surrogate():
+    surrogate = ScipyGPSurrogate(gp=GaussianProcessRegressor(kernel=Matern()))
+    lcb = LCB(surrogate=surrogate)
+
+    return lcb, surrogate
+
+
+def poi_and_surrogate():
+    surrogate = ScipyGPSurrogate(gp=GaussianProcessRegressor(kernel=Matern()))
+    poi = POI(surrogate=surrogate)
+
+    return poi, surrogate
+
+
+@pytest.mark.parametrize(
+    "acquisition, surrogate",
+    [ei_and_surrogate(), lcb_and_surrogate(), poi_and_surrogate()],
+)
+def test_fit_must_be_called_before_evaluating(acquisition, surrogate):
     # ARRANGE
     n_dimensions = 1
     n_samples = 10
 
-    x, y = make_regression(n_samples, n_dimensions)
+    x, y = make_regression(n_samples=n_samples, n_features=n_dimensions)
 
-    gp = GaussianProcessRegressor(kernel=Matern(nu=1.5))
-    surrogate = ScipyGPSurrogate(gp=gp)
     surrogate.fit(x, y)
 
     # ACT/ASSERT
     with pytest.raises(NotFittedError, match="must call fit before evaluating."):
-        acquisition(surrogate, x)
+        acquisition(x)
 
 
-@pytest.mark.parametrize("acquisition", [EI(), LCB(), POI()])
-def test_output_dimensions_are_correct(acquisition):
+@pytest.mark.parametrize(
+    "acquisition, surrogate",
+    [ei_and_surrogate(), lcb_and_surrogate(), poi_and_surrogate()],
+)
+def test_output_dimensions_are_correct(acquisition, surrogate):
     # ARRANGE
     n_dimensions = 1
     n_samples = 10
 
     x, y = make_regression(n_samples, n_dimensions)
-
-    gp = GaussianProcessRegressor(kernel=Matern(nu=1.5))
-    surrogate = ScipyGPSurrogate(gp=gp)
 
     surrogate.fit(x, y)
     acquisition.fit(x, y)
 
     # ACT
-    a_x = acquisition(surrogate, x)
+    a_x = acquisition(x)
 
     # ASSERT
     assert a_x.shape == (n_samples,)

--- a/tests/test_bayes_opt.py
+++ b/tests/test_bayes_opt.py
@@ -19,11 +19,12 @@ def bo():
         )
 
     surrogate = GPyGPSurrogate(gp_initializer=gp_initializer)
+    acquistion_function = LCB(surrogate=surrogate)
 
     return BayesOpt(
         objective_function=forrester,
         surrogate=surrogate,
-        acquisition_function=LCB(),
+        acquisition_function=acquistion_function,
         optimizer=DirectOptimizer(maxf=100),
         initial_design=UniformRandomInitialDesign(),
         bounds=Bounds(bounds=[Bound(lower=0.0, upper=1.0)]),

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -51,11 +51,12 @@ def test_all_callbacks_are_dispatched():
         )
 
     surrogate = GPyGPSurrogate(gp_initializer=gp_initializer)
+    acquistion_function = LCB(surrogate=surrogate)
 
     bo = BayesOpt(
         objective_function=forrester,
         surrogate=surrogate,
-        acquisition_function=LCB(),
+        acquisition_function=acquistion_function,
         optimizer=DirectOptimizer(maxf=100),
         initial_design=UniformRandomInitialDesign(),
         bounds=Bounds(bounds=[Bound(lower=0.0, upper=1.0)]),


### PR DESCRIPTION
Acquisition functions now maintain a reference to the surrogate model. This simplifies the arguments to a number of functions and makes future implementation of batch methods a little simpler.