### PR TITLE
Swap to scipydirect to be able to silence output and remove *direct_args

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,9 +17,9 @@ pydoe = "*"
 scikit-learn = "*"
 matplotlib = "*"
 seaborn = "*"
-direct = "*"
 bopy = {editable = true,path = "."}
 gpy = "*"
+scipydirect = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dfa8f3c44eeea8e8f1404bd9a66906a43fa23661ddc1d5a56dd342ae99d4c871"
+            "sha256": "f830c33bb1bb75eaee60d07c04844333373f1c05266396cffcb8be66ab2e91b6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -33,13 +33,6 @@
                 "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"
             ],
             "version": "==4.4.1"
-        },
-        "direct": {
-            "hashes": [
-                "sha256:0506117d7d9dceea21805a8c41e3cb331712319187a30930142453eb61728cb4"
-            ],
-            "index": "pypi",
-            "version": "==1.0.1"
         },
         "gpy": {
             "hashes": [
@@ -258,6 +251,13 @@
             ],
             "version": "==1.4.1"
         },
+        "scipydirect": {
+            "hashes": [
+                "sha256:b7bed2cf24723038677cb69a642ed58b02fd975d0a69f6b4dd7e507a91294153"
+            ],
+            "index": "pypi",
+            "version": "==1.3"
+        },
         "seaborn": {
             "hashes": [
                 "sha256:59fe414e138d7d5ea08b0feb01b86caf4682e36fa748e3987730523a89aecbb9",
@@ -294,7 +294,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "attrs": {


### PR DESCRIPTION
Using scipy direct instead of direct allows us to silence the output of direct. Thank god.