### PR TITLE
Silence GPy deprecation warnings

### DIFF
--- a/bopy/surrogate.py
+++ b/bopy/surrogate.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable, Tuple
 
 import GPy
@@ -172,10 +173,13 @@ class GPyGPSurrogate(Surrogate):
         return mu.flatten(), sigma
 
     def _update_gp(self, x: np.ndarray, y: np.ndarray):
-        if self.gp is None:
-            self.gp = self.gp_initializer(x, y)
-        else:
-            self.gp.set_XY(x, y)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+
+            if self.gp is None:
+                self.gp = self.gp_initializer(x, y)
+            else:
+                self.gp.set_XY(x, y)
 
     def _optimize_gp(self):
         self.gp.optimize_restarts(self.n_restarts)

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -1,7 +1,6 @@
 import GPy
 import numpy as np
 import pytest
-from sklearn.datasets import make_regression
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import Matern
 
@@ -93,10 +92,9 @@ def test_training_target_must_be_1d(surrogate):
 @pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
 def test_fit_must_be_called_before_predict(surrogate):
     # ARRANGE
-    n_dimensions = 1
     n_samples = 100
 
-    x, y = make_regression(n_samples, n_dimensions)
+    x, y = make_dataset(n_samples=n_samples)
 
     # ACT/ASSERT
     with pytest.raises(NotFittedError, match="fit must be called before predict"):
@@ -156,11 +154,11 @@ def test_test_input_must_have_same_number_of_dimensions_as_training_input(surrog
     n_dimensions_train = 1
     n_samples_train = 10
 
-    n_dimensions_test = 15
+    n_dimensions_test = 2
     n_samples_test = 10
 
-    x_train, y_train = make_regression(n_samples_train, n_dimensions_train)
-    x_test, _ = make_regression(n_samples_test, n_dimensions_test)
+    x_train, y_train = make_dataset(n_samples_train)
+    x_test = np.random.uniform(size=(n_samples_test, n_dimensions_test))
 
     surrogate.fit(x_train, y_train)
 


### PR DESCRIPTION
GPy seems to be doing something unsafe with one of its dependencies. For now we just filter those errors out to prevent them from polluting the test output.