### PR TITLE
Add reference to data in surrogate

### DIFF
--- a/bopy/surrogate.py
+++ b/bopy/surrogate.py
@@ -11,6 +11,7 @@ from .mixin import FittableMixin
 
 __all__ = ["ScipyGPSurrogate"]
 
+
 class Surrogate(FittableMixin, ABC):
     """Surrogate model base class.
 
@@ -23,6 +24,8 @@ class Surrogate(FittableMixin, ABC):
         super().__init__()
         self.has_been_fitted = False
         self.n_dimensions = -1
+        self.x = np.array([])
+        self.y = np.array([])
 
     def fit(self, x: np.ndarray, y: np.ndarray) -> None:
         """Fit the surrogate model to training data.
@@ -35,8 +38,13 @@ class Surrogate(FittableMixin, ABC):
             The training target.
         """
         self._validate_ok_for_fitting(x, y)
+        self._update_data(x, y)
         self._fit(x, y)
         self._confirm_fit()
+
+    def _update_data(self, x: np.ndarray, y: np.ndarray) -> None:
+        self.x = x
+        self.y = y
 
     @abstractmethod
     def _fit(self, x: np.ndarray, y: np.ndarray) -> None:

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -159,6 +159,21 @@ def test_test_input_must_be_2d(surrogate):
 
 
 @pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
+def test_surrogate_updates_data_references(surrogate):
+    # ARRANGE
+    n_samples = 10
+
+    x_train, y_train = make_dataset(n_samples=n_samples)
+
+    # ACT
+    surrogate.fit(x_train, y_train)
+
+    # ASSERT
+    assert np.array_equal(x_train, surrogate.x)
+    assert np.array_equal(y_train, surrogate.y)
+
+
+@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
 def test_test_input_must_have_same_number_of_dimensions_as_training_input(surrogate):
     # ARRANGE
     n_dimensions_train = 1


### PR DESCRIPTION
Surrogates now maintain a reference to the data they were trained on. This should be of use for batch methods that need to know about the current training data.