### PR TITLE
Fix base_acquisition bug

### DIFF
--- a/examples/example_batch_1d.py
+++ b/examples/example_batch_1d.py
@@ -88,7 +88,7 @@ bounds = Bounds(bounds=[Bound(lower=0.0, upper=1.0)])
 # the SequentialBatchOptimizer for sequentially constructing
 # a batch of points to evaluate.
 base_optimizer = DirectOptimizer(
-    acquisition_function=base_acquisition, bounds=bounds, maxf=100
+    acquisition_function=acquisition_function, bounds=bounds, maxf=100
 )
 optimizer = SequentialBatchOptimizer(
     base_optimizer=base_optimizer,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -46,7 +46,7 @@ def sequential_batch_and_surrogate():
     bounds = Bounds(bounds=[Bound(lower=0.0, upper=1.0)])
 
     base_optimizer = DirectOptimizer(
-        acquisition_function=base_acquisition, bounds=bounds, maxf=100
+        acquisition_function=acquisition_function, bounds=bounds, maxf=100
     )
     optimizer = SequentialBatchOptimizer(
         base_optimizer=base_optimizer,


### PR DESCRIPTION
In both the example and test suite, base_optimizers were being created with references to base_acquisitions. However, this shouldn't be the case. They don't need to know about the existence of base_acquisitions. Thus, this has now been changed so they get a reference to the acquisiton_function instead.