### PR TITLE
Refactor tests to make (heavy) use of fixtures

### DIFF
--- a/tests/test_bayes_opt.py
+++ b/tests/test_bayes_opt.py
@@ -11,162 +11,116 @@ from bopy.optimizer import DirectOptimizer
 from bopy.surrogate import GPyGPSurrogate
 
 
-@pytest.fixture
-def bo():
+@pytest.fixture(scope="class", autouse=True)
+def surrogate():
     def gp_initializer(x, y):
         return GPy.models.GPRegression(
             x, y, kernel=GPy.kern.RBF(input_dim=1), noise_var=1e-5, normalizer=True
         )
 
-    surrogate = GPyGPSurrogate(gp_initializer=gp_initializer)
-    acquistion_function = LCB(surrogate=surrogate)
-    bounds = Bounds(bounds=[Bound(lower=0.0, upper=1.0)])
-    optimizer = DirectOptimizer(
-        acquisition_function=acquistion_function, bounds=bounds, maxf=100
-    )
+    return GPyGPSurrogate(gp_initializer=gp_initializer)
 
+
+@pytest.fixture(scope="class", autouse=True)
+def acquisition(surrogate):
+    return LCB(surrogate=surrogate)
+
+
+@pytest.fixture(scope="class", autouse=True)
+def bounds():
+    return Bounds(bounds=[Bound(lower=0.0, upper=1.0)])
+
+
+@pytest.fixture(scope="class", autouse=True)
+def optimizer(acquisition, bounds):
+    return DirectOptimizer(acquisition_function=acquisition, bounds=bounds, maxf=100)
+
+
+@pytest.fixture(scope="class", autouse=True)
+def bo(surrogate, acquisition, optimizer, bounds):
     return BayesOpt(
         objective_function=forrester,
         surrogate=surrogate,
-        acquisition_function=acquistion_function,
+        acquisition_function=acquisition,
         optimizer=optimizer,
         initial_design=UniformRandomInitialDesign(),
         bounds=bounds,
     )
 
 
-def test_run_initial_design_results_in_correct_shaped_dataset(bo):
-    # ARRANGE
-    n_initial_design = 5
+n_initial_design = 5
 
-    # ACT
+
+@pytest.fixture(scope="class")
+def bo_after_initial_design(bo):
     bo.run_initial_design(n_initial_design)
-
-    # ASSERT
-    assert bo.x.shape == (n_initial_design, 1)
-    assert bo.y.shape == (n_initial_design,)
+    return bo
 
 
-def test_run_initial_design_returns_the_correct_shaped_results(bo):
-    # ARRANGE
-    n_initial_design = 5
+class TestAfterRunningInitialDesign:
+    @pytest.fixture(scope="class", autouse=True)
+    def initial_design_result(self, bo):
+        return bo.run_initial_design(n_initial_design)
 
-    # ACT
-    initial_design_result = bo.run_initial_design(n_initial_design)
+    def test_xs_selected_is_the_correct_shape(self, initial_design_result):
+        assert initial_design_result.xs_selected.shape == (n_initial_design, 1)
 
-    # ASSERT
-    assert isinstance(initial_design_result, BOInitialDesignResult)
-    assert initial_design_result.xs_selected.shape == (n_initial_design, 1)
-    assert initial_design_result.f_of_xs_selected.shape == (n_initial_design,)
-    assert initial_design_result.x_opt_so_far.shape == (1, 1)
-    assert isinstance(initial_design_result.f_of_x_opt_so_far, float)
+    def test_f_of_xs_selected_is_the_correct_shape(self, initial_design_result):
+        assert initial_design_result.f_of_xs_selected.shape == (n_initial_design,)
 
+    def test_reference_to_x_is_the_correct_shape(self, bo):
+        assert bo.x.shape == (n_initial_design, 1)
 
-def test_run_trial_results_in_correct_shaped_dataset(bo):
-    # ARRANGE
-    n_initial_design = 5
-
-    # ACT
-    bo.run_initial_design(n_initial_design)
-    bo.run_trial()
-
-    # ASSERT
-    assert bo.x.shape == (n_initial_design + 1, 1)
-    assert bo.y.shape == (n_initial_design + 1,)
+    def test_reference_to_y_is_the_correct_shape(self, bo):
+        assert bo.y.shape == (n_initial_design,)
 
 
-def test_run_trial_returns_the_correct_shaped_results(bo):
-    # ARRANGE
-    n_initial_design = 5
-    bo.run_initial_design(n_initial_design)
+class TestAfterRunningTrial:
+    @pytest.fixture(scope="class", autouse=True)
+    def run_trial_result(self, bo_after_initial_design):
+        return bo_after_initial_design.run_trial()
 
-    # ACT
-    trial_result = bo.run_trial()
+    def test_xs_selected_is_the_correct_shape(self, run_trial_result):
+        assert run_trial_result.x_selected.shape == (1, 1)
 
-    # ASSERT
-    assert isinstance(trial_result, BOTrialResult)
-    assert trial_result.x_selected.shape == (1, 1)
-    assert isinstance(trial_result.f_of_x_selected, float)
-    assert trial_result.x_opt_so_far.shape == (1, 1)
-    assert isinstance(trial_result.f_of_x_opt_so_far, float)
+    def test_reference_to_x_is_the_correct_shape(self, bo):
+        assert bo.x.shape == (n_initial_design + 1, 1)
 
-
-def test_run_trials_results_in_correct_shaped_dataset(bo):
-    # ARRANGE
-    n_initial_design = 5
-    n_trials = 2
-    bo.run_initial_design(n_initial_design)
-
-    # ACT
-    bo.run_trials(n_trials)
-
-    # ASSERT
-    assert bo.x.shape == (n_initial_design + n_trials, 1)
-    assert bo.y.shape == (n_initial_design + n_trials,)
+    def test_reference_to_y_is_the_correct_shape(self, bo):
+        assert bo.y.shape == (n_initial_design + 1,)
 
 
-def test_run_trials_returns_the_correct_shaped_results(bo):
-    # ARRANGE
-    n_initial_design = 5
-    n_trials = 2
-    bo.run_initial_design(n_initial_design)
-
-    # ACT
-    trial_results = bo.run_trials(n_trials)
-
-    # ASSERT
-    assert len(trial_results) == n_trials
-    assert isinstance(trial_results[0], BOTrialResult)
+n_trials = 2
 
 
-def test_run_results_in_correct_shaped_dataset(bo):
-    # ARRANGE
-    n_initial_design = 5
-    n_trials = 2
+class TestAfterRunningTrials:
+    @pytest.fixture(scope="class", autouse=True)
+    def run_trials_result(self, bo_after_initial_design):
+        return bo_after_initial_design.run_trials(n_trials)
 
-    # ACT
-    bo.run(n_trials=n_trials, n_initial_design=n_initial_design)
+    def test_reference_to_x_is_the_correct_shape(self, bo):
+        assert bo.x.shape == (n_initial_design + n_trials, 1)
 
-    # ASSERT
-    assert bo.x.shape == (n_initial_design + n_trials, 1)
-    assert bo.y.shape == (n_initial_design + n_trials,)
+    def test_reference_to_y_is_the_correct_shape(self, bo):
+        assert bo.y.shape == (n_initial_design + n_trials,)
 
-
-def test_run_returns_correct_shaped_results(bo):
-    # ARRANGE
-    n_initial_design = 5
-    n_trials = 2
-
-    # ACT
-    result = bo.run(n_trials=n_trials, n_initial_design=n_initial_design)
-
-    # ASSERT
-    assert isinstance(result, BOResult)
-    assert result.x_opt.shape == (1, 1)
-    assert isinstance(result.f_of_x_opt, float)
-    assert isinstance(result.initial_design_result, BOInitialDesignResult)
-    assert len(result.trial_results) == n_trials
-    assert isinstance(result.trial_results[0], BOTrialResult)
+    def test_run_trials_result_is_the_correct_length(self, run_trials_result):
+        assert len(run_trials_result) == n_trials
 
 
-def test_append_to_dataset(bo):
-    # ARRANGE
-    n_samples = 100
-    n_dimensions = 1
+class TestAfterRunning:
+    @pytest.fixture(scope="class", autouse=True)
+    def run_result(self, bo):
+        return bo.run(n_trials=n_trials, n_initial_design=n_initial_design)
 
-    x = np.zeros((n_samples, n_dimensions))
-    y = np.zeros((n_samples,))
+    def test_reference_to_x_is_the_correct_shape(self, bo):
+        assert bo.x.shape == (n_initial_design + n_trials, 1)
 
-    # ACT
-    bo.append_to_dataset(x, y)
+    def test_reference_to_y_is_the_correct_shape(self, bo):
+        assert bo.y.shape == (n_initial_design + n_trials,)
 
-    # ASSERT
-    assert bo.x.shape == (n_samples, n_dimensions)
-    assert bo.y.shape == (n_samples,)
+    def test_x_opt_is_the_correct_shape(self, run_result):
+        assert run_result.x_opt.shape == (1, 1)
 
-    # ACT
-    bo.append_to_dataset(x, y)
-
-    # ASSERT
-    assert bo.x.shape == (2 * n_samples, n_dimensions)
-    assert bo.y.shape == (2 * n_samples,)
+    def test_trials_results_is_the_correct_length(self, run_result):
+        assert len(run_result.trial_results) == n_trials

--- a/tests/test_bound.py
+++ b/tests/test_bound.py
@@ -1,50 +1,41 @@
+import pytest
 from pytest import raises
 
 from bopy.bounds import Bound, Bounds
 
 
-def test_lower_must_be_less_than_upper_bound():
-    # ACT/ASSERT
-    with raises(ValueError):
-        Bound(lower=1.0, upper=0.0)
+class TestBoundCreation:
+    def test_lower_must_be_less_than_upper(self):
+        with raises(ValueError):
+            Bound(lower=1.0, upper=0.0)
 
 
-def test_bounds_requires_at_least_one_bound():
-    # ACT/ASSERT
-    with raises(ValueError, match="`bounds` must contain at least one bound."):
-        Bounds(bounds=[])
+class TestBoundsCreation:
+    def test_at_least_one_bound_is_required(self):
+        with raises(ValueError, match="`bounds` must contain at least one bound."):
+            Bounds(bounds=[])
 
 
-def test_n_dimensions_returns_the_number_of_dimensions():
-    # ARRANGE
+class TestBoundsAfterCreation:
     n_dimensions = 10
 
-    # ACT
-    bounds = Bounds(bounds=[Bound(lower=0.0, upper=1.0) for _ in range(n_dimensions)])
+    @pytest.fixture(scope="class", autouse=True)
+    def lowers(self):
+        return [i for i in range(1, self.n_dimensions + 1)]
 
-    # ASSERT
-    assert bounds.n_dimensions == n_dimensions
+    @pytest.fixture(scope="class", autouse=True)
+    def uppers(self):
+        return [2 * i for i in range(1, self.n_dimensions + 1)]
 
+    @pytest.fixture(scope="class", autouse=True)
+    def bounds(self, lowers, uppers):
+        return Bounds(bounds=[Bound(lower=l, upper=u) for l, u in zip(lowers, uppers)])
 
-def test_lowers_returns_list_of_lower_bounds():
-    # ARRANGE
-    lowers = [0.0, 1.0, 2.0]
-    uppers = [1.0, 2.0, 3.0]
+    def test_n_dimensions_is_correct(self, bounds):
+        assert bounds.n_dimensions == self.n_dimensions
 
-    # ACT
-    bounds = Bounds(bounds=[Bound(lower=l, upper=u) for l, u in zip(lowers, uppers)])
+    def test_lowers_is_correct(self, bounds, lowers):
+        assert bounds.lowers == lowers
 
-    # ASSERT
-    assert bounds.lowers == lowers
-
-
-def test_uppers_returns_list_of_upper_bounds():
-    # ARRANGE
-    lowers = [0.0, 1.0, 2.0]
-    uppers = [1.0, 2.0, 3.0]
-
-    # ACT
-    bounds = Bounds(bounds=[Bound(lower=l, upper=u) for l, u in zip(lowers, uppers)])
-
-    # ASSERT
-    assert bounds.uppers == uppers
+    def test_uppers_is_correct(self, bounds, uppers):
+        assert bounds.uppers == uppers

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,5 +1,6 @@
 import GPy
 import numpy as np
+import pytest
 
 from bopy.acquisition import LCB
 from bopy.bayes_opt import BayesOpt
@@ -11,72 +12,98 @@ from bopy.optimizer import DirectOptimizer
 from bopy.surrogate import GPyGPSurrogate
 
 
-def test_all_callbacks_are_dispatched():
-    # ARRANGE
-    on_initial_design_end_raised = False
-    on_acquisition_optimized_rasied = False
-    on_acquisition_updated_rasied = False
-    on_surrogate_updated_rasied = False
-    on_trial_end_raised = False
-    on_bo_end_raised = False
-
-    class MyCallback(Callback):
-        def on_initial_design_end(self, bo):
-            nonlocal on_initial_design_end_raised
-            on_initial_design_end_raised = True
-
-        def on_acquisition_optimized(self, bo, opt_result):
-            nonlocal on_acquisition_optimized_rasied
-            on_acquisition_optimized_rasied = True
-
-        def on_acquisition_updated(self, bo):
-            nonlocal on_acquisition_updated_rasied
-            on_acquisition_updated_rasied = True
-
-        def on_surrogate_updated(self, bo):
-            nonlocal on_surrogate_updated_rasied
-            on_surrogate_updated_rasied = True
-
-        def on_trial_end(self, bo):
-            nonlocal on_trial_end_raised
-            on_trial_end_raised = True
-
-        def on_bo_end(self, bo):
-            nonlocal on_bo_end_raised
-            on_bo_end_raised = True
-
+@pytest.fixture(scope="module", autouse=True)
+def surrogate():
     def gp_initializer(x, y):
         return GPy.models.GPRegression(
             x, y, kernel=GPy.kern.RBF(input_dim=1), noise_var=1e-5, normalizer=True
         )
 
-    surrogate = GPyGPSurrogate(gp_initializer=gp_initializer)
-    acquistion_function = LCB(surrogate=surrogate)
-    bounds = Bounds(bounds=[Bound(lower=0.0, upper=1.0)])
-    optimizer = DirectOptimizer(
-        acquisition_function=acquistion_function, bounds=bounds, maxf=100
-    )
+    return GPyGPSurrogate(gp_initializer=gp_initializer)
 
-    bo = BayesOpt(
+
+@pytest.fixture(scope="module", autouse=True)
+def acquisition(surrogate):
+    return LCB(surrogate=surrogate)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def bounds():
+    return Bounds(bounds=[Bound(lower=0.0, upper=1.0)])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def optimizer(acquisition, bounds):
+    return DirectOptimizer(acquisition_function=acquisition, bounds=bounds, maxf=100)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def callback():
+    class TestCallback(Callback):
+        def __init__(self):
+            super().__init__()
+            on_initial_design_end_raised = False
+            on_acquisition_optimized_rasied = False
+            on_acquisition_updated_rasied = False
+            on_surrogate_updated_rasied = False
+            on_trial_end_raised = False
+            on_bo_end_raised = False
+
+        def on_initial_design_end(self, bo):
+            self.on_initial_design_end_raised = True
+
+        def on_acquisition_optimized(self, bo, opt_result):
+            self.on_acquisition_optimized_rasied = True
+
+        def on_acquisition_updated(self, bo):
+            self.on_acquisition_updated_rasied = True
+
+        def on_surrogate_updated(self, bo):
+            self.on_surrogate_updated_rasied = True
+
+        def on_trial_end(self, bo):
+            self.on_trial_end_raised = True
+
+        def on_bo_end(self, bo):
+            self.on_bo_end_raised = True
+
+    return TestCallback()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def bo(surrogate, acquisition, bounds, optimizer, callback):
+    return BayesOpt(
         objective_function=forrester,
         surrogate=surrogate,
-        acquisition_function=acquistion_function,
+        acquisition_function=acquisition,
         optimizer=optimizer,
         initial_design=UniformRandomInitialDesign(),
         bounds=bounds,
-        callbacks=[MyCallback()],
+        callbacks=[callback],
     )
 
-    n_initial_design = 5
-    n_trials = 1
 
-    # ACT
-    bo.run(n_trials=n_trials, n_initial_design=n_initial_design)
+@pytest.fixture(scope="module", autouse=True)
+def bo_after_running(bo):
+    bo.run(n_trials=1, n_initial_design=5)
+    return bo
 
-    # ASSERT
-    assert on_initial_design_end_raised == True
-    assert on_acquisition_optimized_rasied == True
-    assert on_acquisition_updated_rasied == True
-    assert on_surrogate_updated_rasied == True
-    assert on_trial_end_raised == True
-    assert on_bo_end_raised == True
+
+class TestAfterRunningBO:
+    def test_on_initial_design_end_raised(self, callback):
+        assert callback.on_initial_design_end_raised == True
+
+    def test_on_acquistion_optimized_raised(self, callback):
+        assert callback.on_acquisition_optimized_rasied == True
+
+    def test_on_acuqisition_updated_raised(self, callback):
+        assert callback.on_acquisition_updated_rasied == True
+
+    def test_on_surrogate_update_raised(self, callback):
+        assert callback.on_surrogate_updated_rasied == True
+
+    def test_on_trial_end_raised(self, callback):
+        assert callback.on_trial_end_raised == True
+
+    def test_on_bo_end_raised(self, callback):
+        assert callback.on_bo_end_raised == True

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -8,12 +8,17 @@ from bopy.benchmark_functions import forrester
 from bopy.exceptions import NotFittedError
 from bopy.surrogate import GPyGPSurrogate, ScipyGPSurrogate
 
+n_samples = 10
 
-def make_dataset(n_samples):
-    x = np.random.uniform(size=(n_samples, 1))
-    y = forrester(x)
 
-    return x, y
+@pytest.fixture(scope="module", autouse=True)
+def x():
+    return np.linspace(0, 1, n_samples).reshape(-1, 1)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def y(x):
+    return forrester(x)
 
 
 def scipy_gp_surrogate():
@@ -31,223 +36,92 @@ def gpy_gp_surrogate():
     return GPyGPSurrogate(gp_initializer=gp_initializer)
 
 
-def noise_free_gpy_gp_surrogate():
-    def gp_initializer(x, y):
-        gp = GPy.models.GPRegression(
-            x, y, kernel=GPy.kern.RBF(input_dim=1), noise_var=1e-10, normalizer=True
-        )
-        gp.Gaussian_noise.fix()
-
-        return gp
-
-    return GPyGPSurrogate(gp_initializer=gp_initializer)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_training_input_must_contain_at_least_one_sample(surrogate):
-    # ARRANGE
-    x, y = np.array([]), np.array([])
-
-    # ACT/ASSERT
-    with pytest.raises(ValueError, match="`x` must contain at least one sample"):
-        surrogate.fit(x, y)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_training_target_must_contain_at_least_one_sample(surrogate):
-    # ARRANGE
-    x, y = np.array([1.0]), np.array([])
-
-    # ACT/ASSERT
-    with pytest.raises(ValueError, match="`y` must contain at least one sample"):
-        surrogate.fit(x, y)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_training_input_and_target_must_be_the_same_size(surrogate):
-    # ARRANGE
-    n_samples_x = 15
-    n_samples_y = 5
-
-    x, y = make_dataset(n_samples=n_samples_x)
-    y = y[:n_samples_y]
-
-    # ACT/ASSERT
-    with pytest.raises(
-        ValueError, match="`x` and `y` must have the same number of samples"
-    ):
-        surrogate.fit(x, y)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_training_input_must_be_2d(surrogate):
-    # ARRANGE
-    x, y = np.array([[[1]]]), np.array([1])
-
-    # ACT/ASSERT
-    with pytest.raises(ValueError, match="`x` must be 2D"):
-        surrogate.fit(x, y)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_training_target_must_be_1d(surrogate):
-    # ARRANGE
-    x, y = np.array([[1]]), np.array([[1]])
-
-    # ACT/ASSERT
-    with pytest.raises(ValueError, match="`y` must be 1D"):
-        surrogate.fit(x, y)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_fit_must_be_called_before_predict(surrogate):
-    # ARRANGE
-    n_samples = 100
-
-    x, y = make_dataset(n_samples=n_samples)
-
-    # ACT/ASSERT
-    with pytest.raises(NotFittedError, match="must be fitted first"):
-        surrogate.predict(x)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_predict_returns_correct_dimensions(surrogate):
-    # ARRANGE
-    n_samples = 100
-
-    x, y = make_dataset(n_samples=n_samples)
-
-    surrogate.fit(x, y)
-
-    # ACT
-    y_pred, sigma = surrogate.predict(x)
-
-    # ASSERT
-    assert y_pred.shape == (n_samples,)
-    assert sigma.shape == (n_samples, n_samples)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_test_input_contains_at_least_one_sample(surrogate):
-    # ARRANGE
-    n_samples = 100
-
-    x_train, y_train = make_dataset(n_samples=n_samples)
-    x_test = np.array([])
-
-    surrogate.fit(x_train, y_train)
-
-    # ACT/ASSERT
-    with pytest.raises(ValueError, match="`x` must contain at least one sample"):
-        surrogate.predict(x_test)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_test_input_must_be_2d(surrogate):
-    # ARRANGE
-    n_samples = 10
-
-    x_train, y_train = make_dataset(n_samples=n_samples)
-    x_test = np.zeros((n_samples, 1, 1))
-
-    surrogate.fit(x_train, y_train)
-
-    # ACT/ASSERT
-    with pytest.raises(ValueError, match="`x` must be 2D"):
-        surrogate.predict(x_test)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_surrogate_updates_data_references(surrogate):
-    # ARRANGE
-    n_samples = 10
-
-    x_train, y_train = make_dataset(n_samples=n_samples)
-
-    # ACT
-    surrogate.fit(x_train, y_train)
-
-    # ASSERT
-    assert np.array_equal(x_train, surrogate.x)
-    assert np.array_equal(y_train, surrogate.y)
-
-
-@pytest.mark.parametrize("surrogate", [scipy_gp_surrogate(), gpy_gp_surrogate()])
-def test_test_input_must_have_same_number_of_dimensions_as_training_input(surrogate):
-    # ARRANGE
-    n_dimensions_train = 1
-    n_samples_train = 10
-
-    n_dimensions_test = 2
-    n_samples_test = 10
-
-    x_train, y_train = make_dataset(n_samples_train)
-    x_test = np.random.uniform(size=(n_samples_test, n_dimensions_test))
-
-    surrogate.fit(x_train, y_train)
-
-    # ACT/ASSERT
-    with pytest.raises(
-        ValueError,
-        match="`x` must have the same number of dimensions as the training data",
-    ):
-        surrogate.predict(x_test)
-
-
-@pytest.mark.parametrize(
-    "surrogate", [scipy_gp_surrogate(), noise_free_gpy_gp_surrogate()]
+@pytest.fixture(
+    scope="module",
+    autouse=True,
+    params=[scipy_gp_surrogate(), gpy_gp_surrogate()],
+    ids=["scipy_gp", "gpy_gp"],
 )
-def test_noise_free_gps_interpolate_the_training_data(surrogate):
-    # ARRANGE
-    n_samples = 5
+def surrogate(request):
+    return request.param
 
-    x, y = make_dataset(n_samples)
+
+@pytest.fixture(scope="class")
+def trained_surrogate(surrogate, x, y):
     surrogate.fit(x, y)
-
-    # ACT
-    y_pred, sigma = surrogate.predict(x)
-    var = np.diag(sigma)
-
-    # ASSERT
-    assert np.allclose(y, y_pred, atol=1e-3)
-    assert np.allclose(0, var, atol=1e-3)
+    return surrogate
 
 
-def test_GPyGPSurrogate_instantiates_a_gp_after_calling_fit():
-    # ARRANGE
-    n_dimensions = 1
-    n_samples = 10
+class TestArgumentsToFit:
+    def test_x_must_contain_at_least_one_sample(self, surrogate):
+        with pytest.raises(ValueError, match="`x` must contain at least one sample"):
+            surrogate.fit(x=np.array([]), y=np.array([1.0]))
 
-    x = np.linspace(0.0, 1.0, n_samples).reshape(-1, 1)
-    y = np.sin(x.flatten())
+    def test_y_must_contain_at_least_one_sample(self, surrogate):
+        with pytest.raises(ValueError, match="`y` must contain at least one sample"):
+            surrogate.fit(x=np.array([[1.0]]), y=np.array([]))
 
-    surrogate = gpy_gp_surrogate()
+    def test_x_and_y_must_contain_the_same_number_of_samples(self, surrogate):
+        with pytest.raises(
+            ValueError, match="`x` and `y` must have the same number of samples"
+        ):
+            surrogate.fit(x=np.array([[1.0]]), y=np.array([1.0, 1.0]))
 
-    # ACT
-    surrogate.fit(x, y)
+    def test_x_must_be_2d(self, surrogate):
+        with pytest.raises(ValueError, match="`x` must be 2D"):
+            surrogate.fit(x=np.array([[[1.0]]]), y=np.array([1.0]))
 
-    # ASSERT
-    assert surrogate.gp is not None
+    def test_y_must_be_1d(self, surrogate):
+        with pytest.raises(ValueError, match="`y` must be 1D"):
+            surrogate.fit(x=np.array([[1.0]]), y=np.array([[1.0]]))
 
 
-def test_GPyGPSurrogate_updates_data_on_second_call_to_fit():
-    # ARRANGE
-    n_dimensions = 1
-    n_samples = 10
+class TestBeforeFitting:
+    def test_calling_predict_raises_not_fitted_error(self, surrogate, x):
+        with pytest.raises(NotFittedError, match="must be fitted first"):
+            surrogate.predict(x)
 
-    x1 = np.linspace(0.0, 1.0, n_samples).reshape(-1, 1)
-    y1 = np.sin(x1.flatten())
 
-    x2 = np.linspace(1.0, 2.0, n_samples).reshape(-1, 1)
-    y2 = np.sin(x2.flatten())
+class TestArgumentsToPredictAfterFitting:
+    def test_x_must_contain_at_least_one_sample(self, trained_surrogate):
+        with pytest.raises(ValueError, match="`x` must contain at least one sample"):
+            trained_surrogate.predict(x=np.array([]))
 
-    surrogate = gpy_gp_surrogate()
-    surrogate.fit(x1, y1)
+    def test_x_must_be_2d(self, trained_surrogate):
+        with pytest.raises(ValueError, match="`x` must be 2D"):
+            trained_surrogate.predict(x=np.array([1.0]))
 
-    # ACT
-    surrogate.fit(x2, y2)
+    def test_x_must_have_the_same_number_of_dimensions_as_the_training_data(
+        self, trained_surrogate
+    ):
+        with pytest.raises(
+            ValueError,
+            match="`x` must have the same number of dimensions as the training data",
+        ):
+            trained_surrogate.predict(x=np.array([[1.0, 1.0]]))
 
-    # ASSERT
-    assert np.array_equal(surrogate.gp.X, x2)
-    assert np.array_equal(surrogate.gp.Y, y2.reshape(-1, 1))
+
+class TestAfterPredicting:
+    @pytest.fixture(scope="class", autouse=True)
+    def predictions(self, trained_surrogate, x):
+        return trained_surrogate.predict(x)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def predicted_mean(self, predictions):
+        return predictions[0]
+
+    @pytest.fixture(scope="class", autouse=True)
+    def predicted_var(self, predictions):
+        return predictions[1]
+
+    def test_predicted_mean_is_the_correct_shape(self, predicted_mean):
+        assert predicted_mean.shape == (n_samples,)
+
+    def test_predicted_var_is_the_correct_shape(self, predicted_var):
+        assert predicted_var.shape == (n_samples, n_samples)
+
+    def test_reference_to_x_is_stored(self, trained_surrogate, x):
+        assert np.array_equal(trained_surrogate.x, x)
+
+    def test_reference_to_y_is_stored(self, trained_surrogate, y):
+        assert np.array_equal(trained_surrogate.y, y)


### PR DESCRIPTION
Previously, we had lots of set up code spread between functions, fixtures, and the tests themselves. Now all setup is done in fixtures, and each test contains just a single assert. Tests are now grouped together into classes, both for logical clarity, but also share fixtures.